### PR TITLE
Properly animate SIM PIN entry screen transition.

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardAbsKeyInputView.java
@@ -66,8 +66,12 @@ public abstract class KeyguardAbsKeyInputView extends LinearLayout
     }
 
     public void reset() {
+        reset(false);
+    }
+
+    protected void reset(boolean animateTransition) {
         // start fresh
-        resetPasswordText(false /* animate */);
+        resetPasswordText(animateTransition);
         // if the user is currently locked out, enforce it.
         long deadline = mLockPatternUtils.getLockoutAttemptDeadline();
         if (shouldLockout(deadline)) {

--- a/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardSimPinView.java
@@ -267,7 +267,8 @@ public class KeyguardSimPinView extends KeyguardPinBasedInputView {
         mKgUpdateMonitor.reportSimUnlocked(mSubId);
         mCallback.dismiss(true);
         mShowDefaultMessage = true;
-        reset();
+        // Animate the transition in case we have a second PIN to enter
+        reset(true);
     }
 
     @Override


### PR DESCRIPTION
Currently, in the MSIM case, the transition between the PIN entry
screens of SIM1 and SIM2 isn't animated, leading to subpar UX. Fix this
by clearing the previously entered PIN of SIM1 in an animated way when
switching to the SIM2 PIN screen.

Change-Id: I7cb6c19590817c47950403e3022d770655ddd2ac